### PR TITLE
Remove LI check in GDPR consent handler

### DIFF
--- a/src/main/java/org/sharedid/endpoint/consent/GdprConsentString.java
+++ b/src/main/java/org/sharedid/endpoint/consent/GdprConsentString.java
@@ -70,12 +70,6 @@ public class GdprConsentString {
             return false;
         }
 
-        boolean hasLegitimateInterest = tcString.getVendorLegitimateInterest().contains(vendorId);
-
-        if (!hasLegitimateInterest) {
-            return false;
-        }
-
         //Cory (4/6/2020): Ignoring LI transparency fields for now...
 
         boolean hasPublisherRestrictions = tcString.getPublisherRestrictions().stream().anyMatch(publisherRestriction -> {

--- a/src/test/java/org/sharedid/endpoint/handler/CheckGdprConsentHandlerTest.java
+++ b/src/test/java/org/sharedid/endpoint/handler/CheckGdprConsentHandlerTest.java
@@ -53,7 +53,7 @@ public class CheckGdprConsentHandlerTest {
 
         when(metricRegistry.meter(anyString())).thenReturn(meter);
 
-        handler = new CheckGdprConsentHandler(metricRegistry, 52);
+        handler = new CheckGdprConsentHandler(metricRegistry, 887);
     }
 
     @Test
@@ -105,7 +105,7 @@ public class CheckGdprConsentHandlerTest {
     public void testGdprConsentStringGranted() throws Exception {
         when(routingContext.response()).thenReturn(response);
 
-        String consentString = "COuQACgOuQACgM-AAAENAPCAAIAAAIAAAAAAAjQAQAaACNABABoACEgAgA0A";
+        String consentString = "CPC1ggVPC1ggVM-AAAENBQCAAIAAAAAAAAAAG7wAQG7gAAAA";
 
         GdprConsentString gdprConsentString =
                 new GdprConsentString(consentString);


### PR DESCRIPTION
Fix for https://github.com/prebid/shared-id/issues/21.

Removed LI check in isV2ConsentGiven().

Updated test case to use proper vendor id (887, prebid.org) and removed LI from consentString in testGdprConsentStringGranted(). 