### PR TITLE
Enabled dns hostnames in VPC

### DIFF
--- a/.cloudformation/cluster.yml
+++ b/.cloudformation/cluster.yml
@@ -45,6 +45,7 @@ Resources:
     Type: 'AWS::EC2::VPC'
     Properties:
       CidrBlock: 172.31.0.0/16
+      EnableDnsHostnames: true
   PublicSubnet1:
     Type: 'AWS::EC2::Subnet'
     Properties:


### PR DESCRIPTION
Enabled DNS hostnames in VPC to fix an issue where fargate tasks could not find the host IP address.